### PR TITLE
Moved test code into separate package

### DIFF
--- a/english/english_test.go
+++ b/english/english_test.go
@@ -4,7 +4,7 @@
 	Many of the tests are drawn from cases where this implementation
 	did not match the results of the Python NLTK implementation.
 */
-package english
+package english_test
 
 import (
 	"github.com/kljensen/snowball/romance"

--- a/english/vocab_test.go
+++ b/english/vocab_test.go
@@ -1,4 +1,4 @@
-package english
+package english_test
 
 import (
 	"testing"

--- a/french/french_test.go
+++ b/french/french_test.go
@@ -1,4 +1,4 @@
-package french
+package french_test
 
 import (
 	"github.com/kljensen/snowball/romance"

--- a/french/vocab_test.go
+++ b/french/vocab_test.go
@@ -1,4 +1,4 @@
-package french
+package french_test
 
 import (
 	"testing"

--- a/romance/common_test.go
+++ b/romance/common_test.go
@@ -2,7 +2,7 @@
 	This file contains test runners that are common to
 	the romance languages.
 */
-package romance
+package romance_test
 
 import (
 	"fmt"

--- a/russian/russian_test.go
+++ b/russian/russian_test.go
@@ -1,4 +1,4 @@
-package russian
+package russian_test
 
 import (
 	"github.com/kljensen/snowball/romance"

--- a/russian/vocab_test.go
+++ b/russian/vocab_test.go
@@ -1,4 +1,4 @@
-package russian
+package russian_test
 
 import (
 	"testing"

--- a/snowball_test.go
+++ b/snowball_test.go
@@ -1,8 +1,9 @@
-package snowball
+package snowball_test
 
 import (
 	"regexp"
 	"testing"
+	"github.com/kljensen/snowball"
 )
 
 func Test_Stem(t *testing.T) {
@@ -48,7 +49,7 @@ func Test_Stem(t *testing.T) {
 		{"band", "spanish", true, "band", true},
 	}
 	for _, testCase := range testCases {
-		out, err := Stem(testCase.in, testCase.language, testCase.stemStopWords)
+		out, err := snowball.Stem(testCase.in, testCase.language, testCase.stemStopWords)
 		nilErr := true
 		if err != nil {
 			nilErr = false
@@ -67,7 +68,7 @@ func Test_Stem(t *testing.T) {
 //
 func Test_Version(t *testing.T) {
 	validVersionRegexp := regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
-	if validVersionRegexp.MatchString(VERSION) == false {
-		t.Errorf("Invalid version specified: %v", VERSION)
+	if validVersionRegexp.MatchString(snowball.VERSION) == false {
+		t.Errorf("Invalid version specified: %v", snowball.VERSION)
 	}
 }

--- a/snowballword/snowballword_test.go
+++ b/snowballword/snowballword_test.go
@@ -1,4 +1,4 @@
-package snowballword
+package snowballword_test
 
 import "testing"
 

--- a/spanish/spanish_test.go
+++ b/spanish/spanish_test.go
@@ -1,4 +1,4 @@
-package spanish
+package spanish_test
 
 import (
 	"github.com/kljensen/snowball/romance"

--- a/spanish/vocab_test.go
+++ b/spanish/vocab_test.go
@@ -1,4 +1,4 @@
-package spanish
+package spanish_test
 
 import (
 	"testing"


### PR DESCRIPTION
This will get rid of test command line flags when someone uses `flags` package

```
 -test.bench string
        regular expression to select benchmarks to run
  -test.benchmem
        print memory allocations for benchmarks
  -test.benchtime duration
```
