### PR TITLE
Move testing helpers into their own package

### DIFF
--- a/french/french_test.go
+++ b/french/french_test.go
@@ -1,7 +1,7 @@
 package french
 
 import (
-	"github.com/kljensen/snowball/romance"
+	"github.com/kljensen/snowball/romance/romancetest"
 	"github.com/kljensen/snowball/snowballword"
 	"testing"
 )
@@ -10,24 +10,24 @@ import (
 // or false.
 //
 func Test_stopWords(t *testing.T) {
-	testCases := []romance.WordBoolTestCase{
+	testCases := []romancetest.WordBoolTestCase{
 		{"eussiez", true},
 		{"machine", false},
 	}
-	romance.RunWordBoolTest(t, isStopWord, testCases)
+	romancetest.RunWordBoolTest(t, isStopWord, testCases)
 }
 
 // Test isLowerVowel for things we know should be true
 // or false.
 //
 func Test_isLowerVowel(t *testing.T) {
-	testCases := []romance.WordBoolTestCase{
+	testCases := []romancetest.WordBoolTestCase{
 		// These are all vowels.
 		{"aeiouyâàëéêèïîôûù", true},
 		// None of these are vowels.
 		{"cbfqhkl", false},
 	}
-	romance.RunRunewiseBoolTest(t, isLowerVowel, testCases)
+	romancetest.RunRunewiseBoolTest(t, isLowerVowel, testCases)
 }
 
 // Test capitalization of vowels acting as non-vowels.
@@ -52,7 +52,7 @@ func Test_capitalizeYUI(t *testing.T) {
 	}
 }
 func Test_findRegions(t *testing.T) {
-	testCases := []romance.FindRegionsTestCase{
+	testCases := []romancetest.FindRegionsTestCase{
 		{"iriez", 2, 5, 3},
 		{"reçoivent", 3, 6, 2},
 		{"rébarbatif", 3, 5, 2},
@@ -155,13 +155,13 @@ func Test_findRegions(t *testing.T) {
 		{"mobile", 3, 5, 2},
 	}
 
-	romance.RunFindRegionsTest(t, findRegions, testCases)
+	romancetest.RunFindRegionsTest(t, findRegions, testCases)
 }
 
 // Test step1, the removal of standard suffixes.
 //
 func Test_step1(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"rapidement", 3, 5, 2, true, "rapid", 3, 5, 2},
 		{"paresseuse", 3, 5, 3, true, "paress", 3, 5, 3},
 		{"prosaïqUement", 4, 7, 3, true, "prosaïqU", 4, 7, 3},
@@ -262,7 +262,7 @@ func Test_step1(t *testing.T) {
 		{"décidément", 3, 5, 2, false, "décidé", 3, 5, 2},
 		{"condiments", 3, 6, 2, false, "condi", 3, 5, 2},
 	}
-	romance.RunStepTest(t, step1, testCases)
+	romancetest.RunStepTest(t, step1, testCases)
 
 }
 
@@ -271,7 +271,7 @@ func Test_step1(t *testing.T) {
 // Test step1, the removal of standard suffixes.
 //
 func Test_step2a(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"épanoUit", 2, 4, 3, true, "épanoU", 2, 4, 3},
 		{"faillirent", 4, 7, 2, true, "faill", 4, 5, 2},
 		{"acabit", 2, 4, 3, true, "acab", 2, 4, 3},
@@ -373,14 +373,14 @@ func Test_step2a(t *testing.T) {
 		{"compromis", 3, 7, 2, true, "comprom", 3, 7, 2},
 		{"simonie", 3, 5, 2, true, "simon", 3, 5, 2},
 	}
-	romance.RunStepTest(t, step2a, testCases)
+	romancetest.RunStepTest(t, step2a, testCases)
 }
 
 // Test the removal of Verb suffixes in RV that
 // do not begin with "i".
 //
 func Test_step2b(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"posée", 3, 5, 2, true, "pos", 3, 3, 2},
 		{"contentait", 3, 6, 2, true, "content", 3, 6, 2},
 		{"évita", 2, 4, 3, true, "évit", 2, 4, 3},
@@ -482,13 +482,13 @@ func Test_step2b(t *testing.T) {
 		{"abrégea", 2, 5, 4, true, "abrég", 2, 5, 4},
 		{"flattait", 4, 8, 3, true, "flatt", 4, 5, 3},
 	}
-	romance.RunStepTest(t, step2b, testCases)
+	romancetest.RunStepTest(t, step2b, testCases)
 }
 
 // Test the cleaning up of "Y" and "ç" suffixes.
 //
 func Test_step3(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"ennuY", 5, 5, 5, true, "ennui", 5, 5, 5},
 		{"envoY", 5, 5, 4, true, "envoi", 5, 5, 4},
 		{"aboY", 4, 4, 3, true, "aboi", 4, 4, 3},
@@ -515,13 +515,13 @@ func Test_step3(t *testing.T) {
 		{"paY", 3, 3, 3, true, "pai", 3, 3, 3},
 		{"bunhY", 5, 5, 2, true, "bunhi", 5, 5, 2},
 	}
-	romance.RunStepTest(t, step3, testCases)
+	romancetest.RunStepTest(t, step3, testCases)
 }
 
 // Test
 //
 func Test_step4(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"défendues", 3, 5, 2, true, "défendu", 3, 5, 2},
 		{"mormones", 3, 6, 2, true, "mormon", 3, 6, 2},
 		{"souvienne", 4, 7, 2, true, "souvienn", 4, 7, 2},
@@ -623,7 +623,7 @@ func Test_step4(t *testing.T) {
 		{"sympathise", 3, 6, 2, true, "sympathis", 3, 6, 2},
 		{"assidue", 2, 5, 4, true, "assidu", 2, 5, 4},
 	}
-	romance.RunStepTest(t, step4, testCases)
+	romancetest.RunStepTest(t, step4, testCases)
 }
 
 // Test a large set of words for which we know

--- a/romance/romancetest/testing_helpers.go
+++ b/romance/romancetest/testing_helpers.go
@@ -2,7 +2,7 @@
 	This file contains test runners that are common to
 	the romance languages.
 */
-package romance
+package romancetest
 
 import (
 	"fmt"

--- a/russian/russian_test.go
+++ b/russian/russian_test.go
@@ -1,7 +1,7 @@
 package russian
 
 import (
-	"github.com/kljensen/snowball/romance"
+	"github.com/kljensen/snowball/romance/romancetest"
 	"testing"
 )
 
@@ -9,31 +9,31 @@ import (
 // or false.
 //
 func Test_isLowerVowel(t *testing.T) {
-	testCases := []romance.WordBoolTestCase{
+	testCases := []romancetest.WordBoolTestCase{
 		// These are all vowels.
 		{"аеиоуыэюя", true},
 		// None of these are vowels.
 		{"бвгджзйклмнпрстфхцчшщъь", false},
 	}
-	romance.RunRunewiseBoolTest(t, isLowerVowel, testCases)
+	romancetest.RunRunewiseBoolTest(t, isLowerVowel, testCases)
 }
 
 // Test stopWords for things we know should be true
 // or false.
 //
 func Test_stopWords(t *testing.T) {
-	testCases := []romance.WordBoolTestCase{
+	testCases := []romancetest.WordBoolTestCase{
 		{"была", true},
 		{"нас", true},
 		{"меня", true},
 		{"химическое", false},
 		{"машиностроение", false},
 	}
-	romance.RunWordBoolTest(t, isStopWord, testCases)
+	romancetest.RunWordBoolTest(t, isStopWord, testCases)
 }
 
 func Test_findRegions(t *testing.T) {
-	testCases := []romance.FindRegionsTestCase{
+	testCases := []romancetest.FindRegionsTestCase{
 		{"кистей", 3, 6, 2},
 		{"пугает", 3, 6, 2},
 		{"горячей", 3, 5, 2},
@@ -136,13 +136,13 @@ func Test_findRegions(t *testing.T) {
 		{"полярный", 3, 5, 2},
 	}
 
-	romance.RunFindRegionsTest(t, findRegions, testCases)
+	romancetest.RunFindRegionsTest(t, findRegions, testCases)
 }
 
 // Test step1
 //
 func Test_step1(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"оснеженные", 2, 5, 1, true, "оснеженн", 2, 5, 1},
 		{"умираю", 2, 4, 1, true, "умира", 2, 4, 1},
 		{"старосте", 4, 6, 3, true, "старост", 4, 6, 3},
@@ -295,14 +295,14 @@ func Test_step1(t *testing.T) {
 		{"овчинин", 2, 5, 1, false, "овчинин", 2, 5, 1},
 		{"ков", 3, 3, 2, false, "ков", 3, 3, 2},
 	}
-	romance.RunStepTest(t, step1, testCases)
+	romancetest.RunStepTest(t, step1, testCases)
 
 }
 
 // Test step2
 //
 func Test_step2(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"незнани", 3, 6, 2, true, "незнан", 3, 6, 2},
 		{"однообрази", 2, 6, 1, true, "однообраз", 2, 6, 1},
 		{"развити", 3, 6, 2, true, "развит", 3, 6, 2},
@@ -405,14 +405,14 @@ func Test_step2(t *testing.T) {
 		{"додума", 3, 5, 2, false, "додума", 3, 5, 2},
 		{"додума", 3, 5, 2, false, "додума", 3, 5, 2},
 	}
-	romance.RunStepTest(t, step2, testCases)
+	romancetest.RunStepTest(t, step2, testCases)
 
 }
 
 // Test step3
 //
 func Test_step3(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"подробност", 3, 6, 2, true, "подробн", 3, 6, 2},
 		{"подробност", 3, 6, 2, true, "подробн", 3, 6, 2},
 		{"подробност", 3, 6, 2, true, "подробн", 3, 6, 2},
@@ -515,14 +515,14 @@ func Test_step3(t *testing.T) {
 		{"арестант", 2, 4, 1, false, "арестант", 2, 4, 1},
 		{"шепнул", 3, 6, 2, false, "шепнул", 3, 6, 2},
 	}
-	romance.RunStepTest(t, step3, testCases)
+	romancetest.RunStepTest(t, step3, testCases)
 
 }
 
 // Test step4
 //
 func Test_step4(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"раскольничь", 3, 6, 2, true, "раскольнич", 3, 6, 2},
 		{"создань", 3, 6, 2, true, "создан", 3, 6, 2},
 		{"доверенн", 3, 5, 2, true, "доверен", 3, 5, 2},
@@ -625,7 +625,7 @@ func Test_step4(t *testing.T) {
 		{"цепля", 3, 5, 2, false, "цепля", 3, 5, 2},
 		{"дворянин", 4, 6, 3, false, "дворянин", 4, 6, 3},
 	}
-	romance.RunStepTest(t, step4, testCases)
+	romancetest.RunStepTest(t, step4, testCases)
 }
 
 // Test a large set of words for which we know

--- a/spanish/spanish_test.go
+++ b/spanish/spanish_test.go
@@ -1,7 +1,7 @@
 package spanish
 
 import (
-	"github.com/kljensen/snowball/romance"
+	"github.com/kljensen/snowball/romance/romancetest"
 	"testing"
 )
 
@@ -9,31 +9,31 @@ import (
 // or false.
 //
 func Test_stopWords(t *testing.T) {
-	testCases := []romance.WordBoolTestCase{
+	testCases := []romancetest.WordBoolTestCase{
 		{"el", true},
 		{"queso", false},
 	}
-	romance.RunWordBoolTest(t, isStopWord, testCases)
+	romancetest.RunWordBoolTest(t, isStopWord, testCases)
 }
 
 // Test isLowerVowel for things we know should be true
 // or false.
 //
 func Test_isLowerVowel(t *testing.T) {
-	testCases := []romance.WordBoolTestCase{
+	testCases := []romancetest.WordBoolTestCase{
 		// These are all vowels.
 		{"aeiouáéíóúü", true},
 		// None of these are vowels.
 		{"cbfqhkl", false},
 	}
-	romance.RunRunewiseBoolTest(t, isLowerVowel, testCases)
+	romancetest.RunRunewiseBoolTest(t, isLowerVowel, testCases)
 }
 
 // Test isLowerVowel for things we know should be true
 // or false.
 //
 func Test_findRegions(t *testing.T) {
-	testCases := []romance.FindRegionsTestCase{
+	testCases := []romancetest.FindRegionsTestCase{
 		{"macho", 3, 5, 3},
 		{"olivia", 2, 4, 3},
 		{"trabajo", 4, 6, 3},
@@ -139,13 +139,13 @@ func Test_findRegions(t *testing.T) {
 		{"gonzalez", 3, 6, 3},
 		{"antidemocrática", 2, 5, 4},
 	}
-	romance.RunFindRegionsTest(t, findRegions, testCases)
+	romancetest.RunFindRegionsTest(t, findRegions, testCases)
 }
 
 // Test step0, the removal of pronoun suffixes.
 //
 func Test_step0(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"liberarlo", 3, 5, 3, true, "liberar", 3, 5, 3},
 		{"ejecutarse", 2, 4, 3, true, "ejecutar", 2, 4, 3},
 		{"convirtiéndolas", 3, 6, 3, true, "convirtiendo", 3, 6, 3},
@@ -247,13 +247,13 @@ func Test_step0(t *testing.T) {
 		{"establecerse", 2, 5, 4, true, "establecer", 2, 5, 4},
 		{"ponerles", 3, 5, 3, true, "poner", 3, 5, 3},
 	}
-	romance.RunStepTest(t, step0, testCases)
+	romancetest.RunStepTest(t, step0, testCases)
 }
 
 // Test step1, the removal of standard suffixes.
 //
 func Test_step1(t *testing.T) {
-	testCases := []romance.StepTestCase{
+	testCases := []romancetest.StepTestCase{
 		{"retrospectiva", 3, 6, 3, true, "retrospect", 3, 6, 3},
 		{"emperador", 2, 5, 4, true, "emper", 2, 5, 4},
 		{"instalaciones", 2, 6, 5, true, "instal", 2, 6, 5},
@@ -355,5 +355,5 @@ func Test_step1(t *testing.T) {
 		{"gobernador", 3, 5, 3, true, "gobern", 3, 5, 3},
 		{"inexplicable", 2, 4, 3, true, "inexplic", 2, 4, 3},
 	}
-	romance.RunStepTest(t, step1, testCases)
+	romancetest.RunStepTest(t, step1, testCases)
 }


### PR DESCRIPTION
Production code does not need to include testing helpers or the testing
package.